### PR TITLE
If we use inline template with Twig.js in the project, it shouldn't fail

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,9 @@ module.exports = function loader(source) {
       const defaultSave = Object.assign(Twig.Templates.save);
       // eslint-disable-next-line no-param-reassign
       Twig.Templates.save = function customSave(template) {
-        registry.push(path.normalize(template.path));
+        if (template.path) {
+          registry.push(path.normalize(template.path));
+        }
         return defaultSave.call(this, template);
       };
     });


### PR DESCRIPTION
We modify `Twig.Templates.save` directly in Twig.js, so Twig is affected even elsewhere in the project where there is no path.

It's a quick fix.
I think we shouldn't modify Twig.js function members.
But there is no other solution currently (maybe with Twing). 