### PR TITLE
Bump twig from 1.12.0 to 1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,14 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.8.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.7.tgz",
+      "integrity": "sha512-+AATMUFppJDw6aiR5NVPHqIQBlV/Pj8wY/EZH+lmvRdUo9xBaz/rF3alAwFJQavvKfeOlPE7oaaDHVbcySbCsg==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "acorn": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
@@ -257,6 +265,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -869,9 +882,12 @@
       }
     },
     "locutus": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.10.tgz",
-      "integrity": "sha512-AZg2kCqrquMJ5FehDsBidV0qHl98NrsYtseUClzjAQ3HFnsDBJTCwGVplSQ82t9/QfgahqvTjaKcZqZkHmS0wQ=="
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.11.tgz",
+      "integrity": "sha512-C0q1L38lK5q1t+wE0KY21/9szrBHxye6o2z5EJzU+5B79tubNOC+nLAEzTTn1vPUGoUuehKh8kYKqiVUTWRyaQ==",
+      "requires": {
+        "es6-promise": "^4.2.5"
+      }
     },
     "lodash": {
       "version": "4.17.14",
@@ -1154,6 +1170,11 @@
         "read-pkg": "^2.0.0"
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.5",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -1402,11 +1423,12 @@
       "dev": true
     },
     "twig": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/twig/-/twig-1.13.2.tgz",
-      "integrity": "sha512-F7o4sDD2DaIj2II8VrbmDXnompOO6ESNQSh97rtJuif00v5FoUWTlkJE1ZlfeFNAwSCU9rexWsB1+3oF8jmU/Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/twig/-/twig-1.15.0.tgz",
+      "integrity": "sha512-kJkEbF4sTyZcaMAXffCjaUt6ZSD3v6qZQZd9b6mySvfuUIseTCJCvikphAJvrNJTDw7nZDfGorvTtUkzge1HPg==",
       "requires": {
-        "locutus": "^2.0.5",
+        "@babel/runtime": "^7.8.4",
+        "locutus": "^2.0.11",
         "minimatch": "3.0.x",
         "walk": "2.3.x"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "loader-utils": "^1.1.0",
-    "twig": "^1.12.0"
+    "twig": "^1.15.0"
   },
   "devDependencies": {
     "eslint": "^5.7.0",


### PR DESCRIPTION
Current twig.js is six versions behind. This PR bumps the dependency to the latest (see https://github.com/twigjs/twig.js/releases)

Thanks for a useful tool!